### PR TITLE
Removed deprecated warnings, added MPI.so and buffers.so compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
+*.so
+*.sh
 lua-5.1/
 lua-5.2.1/
 /Makefile.in

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ main.o : main.c
 	$(CC) $(CFLAGS) -c -o $@ $< $(LUA_I)
 
 main : main.o lua-mpi.o buffer.o
-	$(CC) $(CFLAGS) -o $@ $^ $(LUA_I) $(LUA_L)
+	$(CC) -o $@ $^ $(LUA_I) $(LUA_L)
 
 clean :
 	$(RM) *.o mpifuncs.c main

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ main.o : main.c
 	$(CC) $(CFLAGS) -c -o $@ $< $(LUA_I)
 
 main : main.o lua-mpi.o buffer.o
-	$(CC) -o $@ $^ $(LUA_I) $(LUA_L)
+	$(CC) -o $@ $^ $(LUA_L)
 
 clean :
 	$(RM) *.o mpifuncs.c main

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@
 MAKEFILE_IN = Makefile.in
 include $(MAKEFILE_IN)
 
-CFLAGS ?= -Wall
+CFLAGS ?= -Wall -shared -fPIC
 CURL ?= curl
 UNTAR ?= tar -xvf
 CD ?= cd
@@ -68,10 +68,10 @@ clean :
 	$(RM) *.o mpifuncs.c main
 
 MPI.so: lua-mpi.o
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ $< $(LUA_I) $(LUA_L)
+	$(CC) $(CFLAGS) -o $@ $< $(LUA_I) $(LUA_L)
 
 buffer.so: buffer.o
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ $< $(LUA_I) $(LUA_L)
+	$(CC) $(CFLAGS) -o $@ $< $(LUA_I) $(LUA_L)
 
 # Also remove local Lua sources
 realclean : clean

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LUA_I ?= -I$(LUA_HOME)/include
 LUA_L ?= -L$(LUA_HOME)/lib -llua
 
 
-default : main
+default : main MPI.so buffer.so
 
 lua : $(LVER)
 
@@ -66,6 +66,12 @@ main : main.o lua-mpi.o buffer.o
 
 clean :
 	$(RM) *.o mpifuncs.c main
+
+MPI.so: lua-mpi.o
+	$(CC) $(CFLAGS) -shared -fPIC -o $@ $< $(LUA_I) $(LUA_L)
+
+buffer.so: buffer.o
+	$(CC) $(CFLAGS) -shared -fPIC -o $@ $< $(LUA_I) $(LUA_L)
 
 # Also remove local Lua sources
 realclean : clean

--- a/lua-mpi.c
+++ b/lua-mpi.c
@@ -49,7 +49,7 @@ MPI_STRUCT_TYPE(File, MPI_FILE_NULL)
 MPI_STRUCT_TYPE(Group, MPI_GROUP_NULL)
 MPI_STRUCT_TYPE(Info, MPI_INFO_NULL)
 MPI_STRUCT_TYPE(Offset, MPI_OFFSET_NULL)
-MPI_STRUCT_TYPE(Op, MPI_DATATYPE_NULL)
+MPI_STRUCT_TYPE(Op, MPI_OP_NULL)
 MPI_STRUCT_TYPE(Request, MPI_REQUEST_NULL)
 MPI_STRUCT_TYPE(Status, MPI_STATUS_NULL)
 MPI_STRUCT_TYPE(Win, MPI_WIN_NULL)
@@ -102,8 +102,10 @@ static void register_constants(lua_State *L)
   luampi_push_MPI_Datatype(L, MPI_2INT, 1); lua_setfield(L, -2, "2INT");
   luampi_push_MPI_Datatype(L, MPI_LONG_DOUBLE_INT, 1); lua_setfield(L, -2, "LONG_DOUBLE_INT");
   luampi_push_MPI_Datatype(L, MPI_PACKED, 1); lua_setfield(L, -2, "PACKED");
-  luampi_push_MPI_Datatype(L, MPI_UB, 1); lua_setfield(L, -2, "UB");
-  luampi_push_MPI_Datatype(L, MPI_LB, 1); lua_setfield(L, -2, "LB");
+  /* DEPRECATED IN MPI 2.0
+     luampi_push_MPI_Datatype(L, MPI_UB, 1); lua_setfield(L, -2, "UB");
+     luampi_push_MPI_Datatype(L, MPI_LB, 1); lua_setfield(L, -2, "LB");
+  */
 
 
   // Null objects
@@ -186,7 +188,7 @@ static void register_constants(lua_State *L)
 }
 
 int luaopen_buffer(lua_State *L);
-int luaopen_mpi(lua_State *L)
+int luaopen_MPI(lua_State *L)
 {
   luaL_Reg mpi_types[] = {
     {"Aint", _MPI_Aint},

--- a/main.c
+++ b/main.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
   // Run the script
   // ---------------------------------------------------------------------------
   if (argc == 1) {
-    printf("usage: main script.lua [arg1=val1 arg2=val2]\n");
+    printf("usage: %s script.lua [arg1=val1 arg2=val2]\n", argv[0]);
   }
   else {
     char luacode[4096];

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 
 
 int luaopen_buffer(lua_State *L);
-int luaopen_mpi(lua_State *L);
+int luaopen_MPI(lua_State *L);
 
 
 int main(int argc, char **argv)
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
   int n;
   lua_State *L = luaL_newstate();
   luaL_openlibs(L);
-  luaL_requiref(L, "MPI", luaopen_mpi, 0); lua_pop(L, 1);
+  luaL_requiref(L, "MPI", luaopen_MPI, 0); lua_pop(L, 1);
   luaL_requiref(L, "buffer", luaopen_buffer, 0); lua_pop(L, 1);
 
 

--- a/readspec.py
+++ b/readspec.py
@@ -53,8 +53,10 @@ mpi_datatypes = [
     'MPI_2INT',
     'MPI_LONG_DOUBLE_INT',
     'MPI_PACKED',
-    'MPI_UB',
-    'MPI_LB' ]
+    # DEPRECRATED IN MPI 2.0   
+    #'MPI_UB',
+    #'MPI_LB'
+    ]
 
 mpi_misc = [
     'MPI_ANY_SOURCE',


### PR DESCRIPTION
this update solves deprecated warnings when using MPI 2.0. I don't know the exact impact of removing UB and LB parameters, I'm starting to use MPI and I found the deprecated warnings. Additionally, this update allow to use lua-mpi as library from other Lua binaries compiles mpi.so and buffers.so).
